### PR TITLE
James Arnold HTT Challenge

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -1,4 +1,17 @@
 /** @type {import('next').NextConfig} */
-const nextConfig = {}
+const nextConfig = {
+  images: {
+    remotePatterns: [
+      {
+        protocol: 'https',
+        hostname: 'avatars.githubusercontent.com',
+      },
+      {
+        protocol: 'https',
+        hostname: 'cloudflare-ipfs.com',
+      },
+    ],
+  },
+}
 
 module.exports = nextConfig

--- a/src/app/challenge/page.tsx
+++ b/src/app/challenge/page.tsx
@@ -1,3 +1,6 @@
+import { User } from '@/app/types';
+import UserList from '@/app/components/User/user-list';
+
 async function getData() {
   const res = await fetch('http://localhost:3000/api');
 
@@ -9,12 +12,15 @@ async function getData() {
 }
 
 export default async function Challenge() {
-  const data = await getData();
+  const data: User[] = await getData();
 
   return (
-    <main className="flex text-black font-serif min-h-screen flex-col  items-start justify-start p-4 w-full">
+    <main className="flex flex-col items-start justify-start w-full min-h-screen p-4 font-serif text-black">
       <h1 className="text-4xl font-bold text-center">The Challenge</h1>
       <div className="flex flex-row flex-wrap gap-4">
+        <div className="flex flex-row flex-wrap">
+          <UserList users={data} />
+        </div>
       </div> 
     </main>
   )

--- a/src/app/components/User/user-card.tsx
+++ b/src/app/components/User/user-card.tsx
@@ -1,0 +1,54 @@
+import { User } from "@/app/types";
+import Card from "@/app/components/card";
+import Image from 'next/image'
+import classNames from "classnames";
+import { memo } from 'react';
+
+/**
+ * This component utilizes the generic Card component expanding it to include an image and a name.
+ * I decided to memoize this component to reduce re-renders and the only state change that
+ * should occur after initial data load is the activeUser boolean.
+ */
+
+type UserCardInterface = {
+  user: User;
+  activeUser: boolean;
+  setSelectedUser: (user: User) => void;
+}
+
+const UserCard = memo(function UserCard({ user, activeUser, setSelectedUser }: UserCardInterface) {
+  return (
+    <div
+      // We can use classNames to do conditional styling like applying the red border when the user is active.
+      className={classNames(["container flex flex-col max-w-lg my-5 mr-5 border-2 rounded-md border-gray-dark min-w-80", activeUser ? "border-red-500" : ""])}
+      onClick={() => setSelectedUser(user)}
+      // Adding data-test attributes for easier hooks into specific elements during testing.
+      data-test="user-card"
+    >
+      <div className="mt-4 ml-4 whitespace-pre">
+        <span className="text-xl font-bold text-gray-600">{user.name}</span>
+      </div>
+      <div className="flex flex-row ml-4">
+        <div className="relative w-20 h-20 mt-4 min-w-20">
+            <Image
+              src={user.image}
+              alt="User Profile Image"
+              fill={true}
+              data-test="user-image"
+            />
+        </div>
+        <Card 
+          id={user.id}
+          title={user.role}
+          subTitle={user.bio}
+          bodyText={user.description}
+          linkText='See Profile'
+          // Some User specific styling to apply to the card and override some of the styling applied to the Title and Subtitle.
+          className='flex-col justify-start max-w-sm border-none mt-0 [&_h1]:text-blue-500 [&_h1]:text-lg [&_h2]:text-gray-400 [&_h2]:font-light'
+          onClick={() => setSelectedUser(user)}
+        />
+      </div>
+    </div>);
+});
+
+export default UserCard;

--- a/src/app/components/User/user-card.tsx
+++ b/src/app/components/User/user-card.tsx
@@ -25,15 +25,16 @@ const UserCard = memo(function UserCard({ user, activeUser, setSelectedUser }: U
       // Adding data-test attributes for easier hooks into specific elements during testing.
       data-test="user-card"
     >
-      <div className="mt-4 ml-4 whitespace-pre">
+      <div className="mt-8 ml-4 -mb-8 whitespace-pre">
         <span className="text-xl font-bold text-gray-600">{user.name}</span>
       </div>
       <div className="flex flex-row ml-4">
-        <div className="relative w-20 h-20 mt-4 min-w-20">
+        <div className="relative w-20 h-20 mt-10 min-w-20">
             <Image
               src={user.image}
               alt="User Profile Image"
               fill={true}
+              sizes="(max-width: 5rem) 100vw"
               data-test="user-image"
             />
         </div>

--- a/src/app/components/User/user-list.tsx
+++ b/src/app/components/User/user-list.tsx
@@ -1,0 +1,31 @@
+'use client';
+import { useState } from "react";
+import { User } from "@/app/types";
+import UserCard from "@/app/components/User/user-card";
+
+/**
+ * Simple component that accepts a list of users and renders 
+ * the cards with a key attached for efficient re-renders.
+ * 
+ * We show a simple message to the user if there are no users provided.
+ */
+
+type UserListInterface = {
+  users: User[];
+}
+
+export default function UserList({ users }: UserListInterface) {
+  const [ selectedUser, setSelectedUser ] = useState<User>();
+
+  if (!users || users.length === 0) {
+   return <span>No Users Found</span>
+  }
+  return users.map((user: User) => (
+    <UserCard 
+      key={user.id}
+      user={user}
+      activeUser={selectedUser === user}
+      setSelectedUser={setSelectedUser}
+    />
+  ));
+};

--- a/src/app/components/card.tsx
+++ b/src/app/components/card.tsx
@@ -1,5 +1,12 @@
-import React, { PropsWithChildren } from 'react';
+'use client';
+import React, { KeyboardEvent, MouseEvent, PropsWithChildren } from 'react';
 import classNames from 'classnames';
+
+/*
+  I tried to not change the Card component.  It seems like a great generic implementation
+  that other parts of the project may utilize and I don't want to introduce User specific
+  features into it.
+*/
 
 export interface CardInterface extends PropsWithChildren {
   className?: string;
@@ -17,13 +24,13 @@ export interface CardInterface extends PropsWithChildren {
 }
 
 export default function Card({ className, id = 0, name, title, subTitle, bodyText, children, count = 0, quantity = 0, link = '#', linkText, onClick, dataTest }: CardInterface) {
-  const cardId = `${ id }`;
+  const cardId = `${id}`;
 
   return (
-    <div className={classNames("flex flex-wrap border-2 border-gray-dark rounded-md mt-6 text-gray-dark dark:b-gray-dark dark:border-gray-cool dark:text-white", className)} id={cardId} data-test="card">
-      <div className="content flex flex-wrap p-4 w-full">
+    <div className={classNames("flex flex-wrap border-2 border-gray-dark rounded-md mt-6 text-gray-dark dark:b-gray-dark dark:border-gray-cool", className)} id={cardId} data-test="card">
+      <div className="flex flex-wrap w-full p-4 content">
         { title && (
-          <h1 className="headline text-xl font-bold capitalize w-full">{title}</h1>
+          <h1 className="w-full text-xl font-bold capitalize headline">{title}</h1>
         )}
         { subTitle && (
           <h2 className="w-full text-base font-semibold capitalize">{subTitle}</h2>
@@ -31,10 +38,10 @@ export default function Card({ className, id = 0, name, title, subTitle, bodyTex
         {bodyText}
         {children}
       </div>
-      <div className="flex justify-end items-center w-full pl-4 pr-4 pt-2 pb-2 bg-gray-light rounded-bl-md rounded-br-md text-sm" data-test="card-footer">
+      <div className="flex items-center justify-end w-full pt-2 pb-2 pl-4 pr-4 text-sm bg-gray-light rounded-bl-md rounded-br-md" data-test="card-footer">
         <a
           href={link}
-          className="flex flex-row font-normal capitalize border-b-2 border-transparent hover:border-black cursor-pointer pb-0 pr-5 relative leading-none"
+          className="relative flex flex-row pb-0 pr-5 font-normal leading-none capitalize border-b-2 border-transparent cursor-pointer hover:border-black"
           data-test={dataTest}
           {...(link === '#' && onClick ? { onClick } : { onClick: () => {} })}
         >

--- a/src/app/types.ts
+++ b/src/app/types.ts
@@ -1,0 +1,8 @@
+export type User = {
+  id: string,
+  name: string,
+  role: string,
+  bio: string,
+  image: string,
+  description: string,
+}


### PR DESCRIPTION
## What
Implementing a display of Users on the home page.  Active selected users have a red border applied to their specific `UserCard`.  

## Details
The `UserCard` extends the generic `Card` component to include a profile image and user name.  The `UserCard` is memoized to reduce the number of re-renders since the props being passes into the `UserCard` are for the most part static.  `data-test` attributes have been added to the `UserCard` for easier hooks into specific elements during testing.

Things I would have liked to do:
- Use SWR on the initial fetch and cache users to reduce the number of requests made.
- Add Cypress testing to test the user flows with this piece of work.
    - `it renders a list of UserCards`
    - `it applies the active border to the currently selected UserCard`
    - `it removes the active border when another UserCard is selected`
- Implement a more responsive `UserCard` design.  The number of cards per row goes from 3 to 1 when reducing screen size but at some point the card does not get any smaller which could be an issue for mobile devices.
    
## For Fun
![user list](https://media.giphy.com/media/4xWGyVKoXqg2eVCiq9/giphy-downsized.gif)